### PR TITLE
Create nox:cobweb.json loot table so nox:cobwebs drop cobwebs/string

### DIFF
--- a/src/main/resources/data/nox/loot_tables/blocks/cobweb.json
+++ b/src/main/resources/data/nox/loot_tables/blocks/cobweb.json
@@ -1,0 +1,57 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "entries": [
+        {
+          "type": "minecraft:alternatives",
+          "children": [
+            {
+              "type": "minecraft:item",
+              "conditions": [
+                {
+                  "condition": "minecraft:alternative",
+                  "terms": [
+                    {
+                      "condition": "minecraft:match_tool",
+                      "predicate": {
+                        "items": [
+                          "minecraft:shears"
+                        ]
+                      }
+                    },
+                    {
+                      "condition": "minecraft:match_tool",
+                      "predicate": {
+                        "enchantments": [
+                          {
+                            "enchantment": "minecraft:silk_touch",
+                            "levels": {
+                              "min": 1
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "name": "minecraft:cobweb"
+            },
+            {
+              "type": "minecraft:item",
+              "conditions": [
+                {
+                  "condition": "minecraft:survives_explosion"
+                }
+              ],
+              "name": "minecraft:string"
+            }
+          ]
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}


### PR DESCRIPTION
This uses the same loot table as the vanilla cobweb, and makes cobwebs renewable. If that's not a good fit for this mod, I'll close this and make a datapack instead.

Nox cobwebs drop vanilla cobwebs when mined with shears, and drop string when mined with anything else. Added because my server is abusing this for infinite cobwebs for PvP and redstone. I couldn't think of any way to make this configurable because it uses data stuff, but I'm very new to this so if there's a way let me know and I'll try to implement it.