### PR TITLE
Bug fix: snowGolemAttackRechargeSpeedMultiplier cast missing

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ minecraft_version=1.19.2
 yarn_mappings=1.19.2+build.28
 loader_version=0.14.10
 # Mod Properties
-mod_version=2.5.1+1.19.2
+mod_version=2.5.2+1.19.2
 maven_group=net.scirave
 archives_base_name=nox
 # Dependencies

--- a/src/main/java/net/scirave/nox/mixin/SnowGolemEntityMixin.java
+++ b/src/main/java/net/scirave/nox/mixin/SnowGolemEntityMixin.java
@@ -23,7 +23,7 @@ public abstract class SnowGolemEntityMixin extends GolemEntityMixin {
 
     @ModifyArgs(method = "initGoals", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/ai/goal/ProjectileAttackGoal;<init>(Lnet/minecraft/entity/ai/RangedAttackMob;DIF)V"))
     public void nox$snowGolemFasterShooting(Args args) {
-        args.set(2, ((int) args.get(2)) / Math.max(NoxConfig.snowGolemAttackRechargeSpeedMultiplier, 0));
+        args.set(2, (int)(((int) args.get(2)) / Math.max(NoxConfig.snowGolemAttackRechargeSpeedMultiplier, 0)));
         args.set(3, ((float) args.get(3)) * Math.max(NoxConfig.snowGolemAttackRangeMultiplier, 1));
     }
     @ModifyArgs(method = "attack", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/projectile/thrown/SnowballEntity;setVelocity(DDDFF)V"))


### PR DESCRIPTION
The division of the intervalTicks / nowGolemAttackRechargeSpeedMultiplier need a cast to Int.

Otherwise snow golems fails to spawn.